### PR TITLE
feat: add assistant id setting for responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Admin‑only generator of **generative p5.js** visualizations using OpenAI **Res
 3. Go to **TanViz → Settings** and set:
    - OpenAI API Key.
    - OpenAI Model (default: `gpt-4o-2024-08-06`).
+   - OpenAI Assistant ID (optional).
    - GitHub Datasets Base (raw URL prefix, e.g. `https://raw.githubusercontent.com/user/repo/branch/path/`).
    - Overlay Logo URL (optional).
 

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -54,6 +54,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
     if ( ! $api_key ) return new WP_REST_Response([ 'error'=>'Missing API key' ],400);
 
     $model  = get_option('tanviz_model','gpt-4o-2024-08-06');
+    $assistant_id = trim( get_option('tanviz_assistant_id','') );
     $prompt = sanitize_textarea_field( (string)$req->get_param('prompt') );
     $dataset_url = esc_url_raw( (string)$req->get_param('dataset_url') );
 
@@ -79,6 +80,10 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
             ]
         ],
     ];
+
+    if ( $assistant_id ) {
+        $body['assistant_id'] = $assistant_id;
+    }
 
     $args = [
         'headers' => [

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 function tanviz_register_settings() {
     register_setting( 'tanviz_settings', 'tanviz_api_key', [ 'type'=>'string', 'sanitize_callback'=>'sanitize_text_field' ] );
     register_setting( 'tanviz_settings', 'tanviz_model',   [ 'type'=>'string', 'sanitize_callback'=>'sanitize_text_field', 'default'=>'gpt-4o-2024-08-06' ] );
+    register_setting( 'tanviz_settings', 'tanviz_assistant_id', [ 'type'=>'string', 'sanitize_callback'=>'sanitize_text_field' ] );
     register_setting( 'tanviz_settings', 'tanviz_datasets_base', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw' ] );
     register_setting( 'tanviz_settings', 'tanviz_logo_url', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw', 'default'=> plugins_url('assets/logo.png', dirname(__FILE__,1) . '/../TanViz.php') ] );
 
@@ -17,6 +18,11 @@ function tanviz_register_settings() {
     add_settings_field( 'tanviz_model', __( 'OpenAI Model', 'TanViz' ), function(){
         $v = esc_attr( get_option('tanviz_model','gpt-4o-2024-08-06') );
         echo '<input type="text" name="tanviz_model" value="'.$v.'" class="regular-text" />';
+    }, 'tanviz', 'tanviz_main' );
+
+    add_settings_field( 'tanviz_assistant_id', __( 'OpenAI Assistant ID', 'TanViz' ), function(){
+        $v = esc_attr( get_option('tanviz_assistant_id','') );
+        echo '<input type="text" name="tanviz_assistant_id" value="'.$v.'" class="regular-text" autocomplete="off" />';
     }, 'tanviz', 'tanviz_main' );
 
     add_settings_field( 'tanviz_datasets_base', __( 'GitHub Datasets Base (raw)', 'TanViz' ), function(){


### PR DESCRIPTION
## Summary
- add OpenAI Assistant ID to settings
- send assistant_id when calling OpenAI Responses API
- document new setting in README

## Testing
- `php -l includes/settings.php`
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689bafd8b0ac833296f41d0fe05c81f6