### PR TITLE
Use Responses API json_schema format

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -50,81 +50,63 @@ add_action('rest_api_init', function(){
 });
 
 function tanviz_rest_generate( WP_REST_Request $req ) {
-    $api_key = trim( get_option('tanviz_api_key','') );
-    if ( ! $api_key ) return new WP_REST_Response([ 'error'=>'Missing API key' ],400);
+    $api_key = trim( get_option( 'tanviz_api_key', '' ) );
+    if ( ! $api_key ) {
+        return new WP_REST_Response( [ 'error' => 'Missing API key' ], 400 );
+    }
 
-    $model  = get_option('tanviz_model','gpt-4o-2024-08-06');
-    $prompt = sanitize_textarea_field( (string)$req->get_param('prompt') );
-    $dataset_url = esc_url_raw( (string)$req->get_param('dataset_url') );
+    $model       = get_option( 'tanviz_model', 'gpt-4o-mini' );
+    $prompt      = sanitize_textarea_field( (string) $req->get_param( 'prompt' ) );
+    $dataset_url = esc_url_raw( (string) $req->get_param( 'dataset_url' ) );
 
     $schema = tanviz_p5_json_schema();
-    $body = [
-        'model' => $model,
-        'text'  => [
-            'format' => [
-                'type'  => 'json_schema',
-                'value' => [
-                    'name'   => 'p5_sketch',
-                    'strict' => true,
-                    'schema' => $schema,
-                ],
+    $body   = [
+        'model'           => $model,
+        'input'           => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
+        'response_format' => [
+            'type'        => 'json_schema',
+            'json_schema' => [
+                'name'   => 'p5js_code_schema',
+                'schema' => $schema,
             ],
-        ],
-        'input' => [
-            [
-                'role' => 'system',
-                'content' => "You are a generator of generative p5.js. Return ONLY JSON per schema. No <script> tags. If remote data fails, inline a sample array. Ensure overlay (title+logo)."
-            ],
-            [
-                'role' => 'user',
-                'content' => tanviz_build_user_content( $dataset_url, $prompt, 20 )
-            ]
         ],
     ];
-
 
     $args = [
         'headers' => [
-            'Authorization' => 'Bearer '.$api_key,
+            'Authorization' => 'Bearer ' . $api_key,
             'Content-Type'  => 'application/json',
         ],
         'timeout' => 60,
-        'body' => wp_json_encode($body),
+        'body'    => wp_json_encode( $body ),
     ];
 
-    $resp = wp_remote_post('https://api.openai.com/v1/responses', $args);
-    if ( is_wp_error($resp) ) return new WP_REST_Response([ 'error'=>$resp->get_error_message() ],500);
-    $code = wp_remote_retrieve_response_code($resp);
-    $raw  = wp_remote_retrieve_body($resp);
-    $json = json_decode($raw, true);
-    if ( $code < 200 || $code >= 300 || ! is_array($json) ) {
-        return new WP_REST_Response([ 'error'=>'API error', 'raw'=>$raw ],500);
+    $resp = wp_remote_post( 'https://api.openai.com/v1/responses', $args );
+    if ( is_wp_error( $resp ) ) {
+        return new WP_REST_Response( [ 'error' => $resp->get_error_message() ], 500 );
     }
 
-    $structured = tanviz_extract_structured($json);
-    if ( ! $structured ) {
-        // last resort: output_text fences
-        if ( isset($json['output_text']) && is_string($json['output_text']) && preg_match('/```(?:p5|javascript|js)?\s*([\s\S]*?)```/i',$json['output_text'],$m) ) {
-            $structured = [ 'code'=> trim($m[1]), 'diagnostics'=>['warnings'=>['Fallback from fences']]];
-        } else {
-            return new WP_REST_Response([ 'error'=>'No structured output', 'raw'=>$json ],502);
-        }
+    $code = wp_remote_retrieve_response_code( $resp );
+    $raw  = wp_remote_retrieve_body( $resp );
+    $json = json_decode( $raw, true );
+    if ( $code < 200 || $code >= 300 || ! is_array( $json ) ) {
+        return new WP_REST_Response( [ 'error' => 'API error', 'raw' => $raw ], 500 );
     }
 
-    $code_p5 = tanviz_normalize_p5_code( $structured['code'] ?? '' );
-    $ok = tanviz_is_valid_p5( $code_p5 );
-    if ( ! $ok ) {
-        $structured['diagnostics']['warnings'][] = 'Code may not be a valid p5 sketch (global or instance).';
+    $structured = tanviz_extract_structured( $json );
+    if ( ! $structured || empty( $structured['code'] ) ) {
+        return new WP_REST_Response( [ 'error' => 'No structured output', 'raw' => $json ], 502 );
     }
 
-    return new WP_REST_Response([
-        'ok' => true,
-        'structured' => [
+    $code_p5 = tanviz_normalize_p5_code( $structured['code'] );
+
+    return new WP_REST_Response(
+        [
+            'ok'   => true,
             'code' => $code_p5,
-            'meta' => $structured['meta'] ?? new stdClass(),
-            'diagnostics' => $structured['diagnostics'] ?? new stdClass(),
-        ]
-    ],200);
+        ],
+        200
+    );
 }
 
 function tanviz_rest_save( WP_REST_Request $req ) {

--- a/includes/schema.php
+++ b/includes/schema.php
@@ -3,33 +3,17 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function tanviz_p5_json_schema() {
     return [
-        'type' => 'object',
-        'additionalProperties' => false,
-        'required' => ['code'],
-        'properties' => [
+        'type'                 => 'object',
+        'properties'           => [
             'code' => [
-                'type' => 'string',
-                'description' => 'Pure p5.js sketch (global or instance). No <script> or HTML.',
-                'minLength' => 20,
-            ],
-            'meta' => [
-                'type' => 'object',
-                'additionalProperties' => false,
-                'properties' => [
-                    'title'  => [ 'type' => 'string' ],
-                    'width'  => [ 'type' => 'integer', 'minimum' => 0 ],
-                    'height' => [ 'type' => 'integer', 'minimum' => 0 ],
-                    'palette'=> [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
-                ],
-            ],
-            'diagnostics' => [
-                'type' => 'object',
-                'additionalProperties' => false,
-                'properties' => [
-                    'warnings' => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
-                    'actions'  => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+                'type'        => 'string',
+                'description' => 'El código p5.js generado',
+                'format'      => [
+                    'name' => 'plain_text',
                 ],
             ],
         ],
+        'required'             => [ 'code' ],
+        'additionalProperties' => false,
     ];
 }

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function tanviz_register_settings() {
     register_setting( 'tanviz_settings', 'tanviz_api_key', [ 'type'=>'string', 'sanitize_callback'=>'sanitize_text_field' ] );
-    register_setting( 'tanviz_settings', 'tanviz_model',   [ 'type'=>'string', 'sanitize_callback'=>'sanitize_text_field', 'default'=>'gpt-4o-2024-08-06' ] );
+    register_setting( 'tanviz_settings', 'tanviz_model',   [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'gpt-4o-mini' ] );
     register_setting( 'tanviz_settings', 'tanviz_datasets_base', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw' ] );
     register_setting( 'tanviz_settings', 'tanviz_logo_url', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw', 'default'=> plugins_url('assets/logo.png', dirname(__FILE__,1) . '/../TanViz.php') ] );
 
@@ -15,8 +15,8 @@ function tanviz_register_settings() {
     }, 'tanviz', 'tanviz_main' );
 
     add_settings_field( 'tanviz_model', __( 'OpenAI Model', 'TanViz' ), function(){
-        $v = esc_attr( get_option('tanviz_model','gpt-4o-2024-08-06') );
-        echo '<input type="text" name="tanviz_model" value="'.$v.'" class="regular-text" />';
+        $v = esc_attr( get_option( 'tanviz_model', 'gpt-4o-mini' ) );
+        echo '<input type="text" name="tanviz_model" value="' . $v . '" class="regular-text" />';
     }, 'tanviz', 'tanviz_main' );
 
 


### PR DESCRIPTION
## Summary
- default model now gpt-4o-mini
- generate endpoint calls Responses API using `response_format` json schema and returns plain p5.js code
- simplified JSON schema for p5.js code with `plain_text` format

## Testing
- `php -l includes/settings.php`
- `php -l includes/schema.php`
- `php -l includes/rest.php`
- `phpcs --standard=WordPress includes/settings.php includes/schema.php includes/rest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bbff1e830833293504fcdc6951670