### PR TITLE
refactor: update Responses API format

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -61,13 +61,15 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
 
     $schema = tanviz_p5_json_schema();
     $body   = [
-        'model'           => $model,
-        'input'           => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
-        'response_format' => [
-            'type'        => 'json_schema',
-            'json_schema' => [
-                'name'   => 'p5js_code_schema',
-                'schema' => $schema,
+        'model' => $model,
+        'input' => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
+        'text'  => [
+            'format' => [
+                'type'        => 'json_schema',
+                'json_schema' => [
+                    'name'   => 'p5js_code_schema',
+                    'schema' => $schema,
+                ],
             ],
         ],
     ];


### PR DESCRIPTION
## Summary
- use new `text.format` field instead of deprecated `response_format` when requesting JSON schema output

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689bc2331aec8332915106cdcc94cff8