### PR TITLE
Add missing text format name for OpenAI responses

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -66,8 +66,8 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'text'  => [
             'format' => [
                 'type'        => 'json_schema',
+                'name'        => 'p5js_code_schema',
                 'json_schema' => [
-                    'name'   => 'p5js_code_schema',
                     'schema' => $schema,
                 ],
             ],


### PR DESCRIPTION
## Summary
- provide required `text.format.name` for structured response requests

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689bc375fda48332af44dadef703ef6f