### PR TITLE
feat: add robust visualization schema

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -66,7 +66,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'text'  => [
             'format' => [
                 'type'        => 'json_schema',
-                'name'        => 'p5js_code_schema',
+                'name'        => 'tanviz_p5_visualizacion',
                 'json_schema' => [
                     'schema' => $schema,
                 ],
@@ -96,19 +96,30 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
     }
 
     $structured = tanviz_extract_structured( $json );
-    if ( ! $structured || empty( $structured['code'] ) ) {
+    if ( ! $structured || empty( $structured['codigo'] ) ) {
         return new WP_REST_Response( [ 'error' => 'No structured output', 'raw' => $json ], 502 );
     }
 
-    $code_p5 = tanviz_normalize_p5_code( $structured['code'] );
+    $code_p5 = tanviz_normalize_p5_code( $structured['codigo'] );
 
-    return new WP_REST_Response(
-        [
-            'ok'   => true,
-            'code' => $code_p5,
-        ],
-        200
-    );
+    $response = [
+        'ok'      => true,
+        'codigo'  => $code_p5,
+    ];
+    if ( isset( $structured['variables'] ) ) {
+        $response['variables'] = $structured['variables'];
+    }
+    if ( isset( $structured['metadata'] ) ) {
+        $response['metadata'] = $structured['metadata'];
+    }
+    if ( isset( $structured['notas'] ) ) {
+        $response['notas'] = $structured['notas'];
+    }
+    if ( isset( $structured['advertencias'] ) ) {
+        $response['advertencias'] = $structured['advertencias'];
+    }
+
+    return new WP_REST_Response( $response, 200 );
 }
 
 function tanviz_rest_save( WP_REST_Request $req ) {

--- a/includes/schema.php
+++ b/includes/schema.php
@@ -3,17 +3,125 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function tanviz_p5_json_schema() {
     return [
-        'type'                 => 'object',
-        'properties'           => [
-            'code' => [
-                'type'        => 'string',
-                'description' => 'El código p5.js generado',
-                'format'      => [
-                    'name' => 'plain_text',
+        '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+        'title' => 'TanViz p5.js Sketch',
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'codigo' => [
+                'type' => 'string',
+                'description' => 'Sketch p5.js (solo JS). Debe incluir function setup() y function draw(). Sin HTML.',
+                'minLength' => 50,
+                'maxLength' => 200000,
+                'pattern' => '(?s)function\\s+setup\\s*\\(\\)[\\s\\S]*function\\s+draw\\s*\\(\\)',
+                'not' => [ 'pattern' => '<\\s*(html|head|body|script|style)\\b' ],
+            ],
+            'variables' => [
+                'type' => 'array',
+                'minItems' => 1,
+                'maxItems' => 60,
+                'items' => [
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => [
+                        'key' => [
+                            'type' => 'string',
+                            'description' => 'Identificador usado en el código.',
+                            'pattern' => '^[A-Za-z_][A-Za-z0-9_\\-]*$',
+                            'minLength' => 2,
+                            'maxLength' => 64,
+                        ],
+                        'label' => [ 'type' => 'string', 'minLength' => 1, 'maxLength' => 120 ],
+                        'type' => [
+                            'type' => 'string',
+                            'enum' => [ 'number', 'select', 'text', 'boolean', 'color', 'range' ],
+                        ],
+                        'default' => (object) [],
+                        'min' => [ 'type' => 'number' ],
+                        'max' => [ 'type' => 'number' ],
+                        'step' => [ 'type' => 'number' ],
+                        'options' => [
+                            'type' => 'array',
+                            'description' => 'Opciones para select',
+                            'minItems' => 1,
+                            'maxItems' => 50,
+                            'items' => [
+                                'anyOf' => [
+                                    [ 'type' => 'string' ],
+                                    [ 'type' => 'number' ],
+                                ],
+                            ],
+                        ],
+                        'description' => [ 'type' => 'string', 'maxLength' => 400 ],
+                    ],
+                    'required' => [ 'key', 'label', 'type', 'default' ],
+                    'allOf' => [
+                        [
+                            'if' => [ 'properties' => [ 'type' => [ 'const' => 'number' ] ], 'required' => [ 'type' ] ],
+                            'then' => [ 'properties' => [ 'default' => [ 'type' => 'number' ] ] ],
+                        ],
+                        [
+                            'if' => [ 'properties' => [ 'type' => [ 'const' => 'range' ] ], 'required' => [ 'type' ] ],
+                            'then' => [
+                                'required' => [ 'min', 'max', 'step' ],
+                                'properties' => [
+                                    'default' => [ 'type' => 'number' ],
+                                    'min' => [ 'type' => 'number' ],
+                                    'max' => [ 'type' => 'number' ],
+                                    'step' => [ 'type' => 'number' ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'if' => [ 'properties' => [ 'type' => [ 'const' => 'boolean' ] ], 'required' => [ 'type' ] ],
+                            'then' => [ 'properties' => [ 'default' => [ 'type' => 'boolean' ] ] ],
+                        ],
+                        [
+                            'if' => [ 'properties' => [ 'type' => [ 'const' => 'text' ] ], 'required' => [ 'type' ] ],
+                            'then' => [ 'properties' => [ 'default' => [ 'type' => 'string' ] ] ],
+                        ],
+                        [
+                            'if' => [ 'properties' => [ 'type' => [ 'const' => 'color' ] ], 'required' => [ 'type' ] ],
+                            'then' => [ 'properties' => [ 'default' => [ 'type' => 'string', 'pattern' => '^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$' ] ] ],
+                        ],
+                        [
+                            'if' => [ 'properties' => [ 'type' => [ 'const' => 'select' ] ], 'required' => [ 'type' ] ],
+                            'then' => [
+                                'required' => [ 'options' ],
+                                'properties' => [
+                                    'default' => [
+                                        'anyOf' => [
+                                            [ 'type' => 'string' ],
+                                            [ 'type' => 'number' ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
             ],
+            'metadata' => [
+                'type' => 'object',
+                'additionalProperties' => false,
+                'properties' => [
+                    'titulo' => [ 'type' => 'string', 'maxLength' => 140 ],
+                    'descripcion' => [ 'type' => 'string', 'maxLength' => 400 ],
+                    'requiereDataset' => [ 'type' => 'boolean' ],
+                    'columnasUsadas' => [
+                        'type' => 'array',
+                        'items' => [ 'type' => 'string' ],
+                        'maxItems' => 50,
+                    ],
+                ],
+            ],
+            'notas' => [ 'type' => 'string', 'maxLength' => 800 ],
+            'advertencias' => [
+                'type' => 'array',
+                'maxItems' => 20,
+                'items' => [ 'type' => 'string', 'maxLength' => 300 ],
+            ],
         ],
-        'required'             => [ 'code' ],
-        'additionalProperties' => false,
+        'required' => [ 'codigo', 'variables' ],
     ];
 }

--- a/includes/structured.php
+++ b/includes/structured.php
@@ -63,7 +63,7 @@ function tanviz_build_user_content( $dataset_url, $user_prompt, $sample_rows = 2
         $lines[] = 'Use loadTable/loadJSON; if fetch fails, create const sample with ~' . intval($sample_rows) . ' rows.';
     }
     $lines[] = 'Output rules:';
-    $lines[] = "- Return ONLY JSON according to schema. 'code' must be p5 (global or instance). No <script>.";
+    $lines[] = "- Return ONLY JSON according to schema. 'codigo' must be p5 (global or instance). No <script>.";
     $lines[] = '- Ensure animation or stochastic behavior (generative). Keep draw efficient.';
     $lines[] = '- Include logic for overlay title and logo.';
     $lines[] = '';


### PR DESCRIPTION
## Summary
- add comprehensive JSON Schema for TanViz p5.js sketches
- wire schema into API request and expose returned fields
- clarify system instructions to expect `codigo` field

## Testing
- `php -l includes/schema.php`
- `php -l includes/rest.php`
- `php -l includes/structured.php`


------
https://chatgpt.com/codex/tasks/task_e_689bcc72efe883329bad067063b1b9d1