### PR TITLE
Fix JSON schema parameter for OpenAI responses

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -65,11 +65,9 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'input' => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
         'text'  => [
             'format' => [
-                'type'        => 'json_schema',
-                'name'        => 'tanviz_p5_visualizacion',
-                'json_schema' => [
-                    'schema' => $schema,
-                ],
+                'type'   => 'json_schema',
+                'name'   => 'tanviz_p5_visualizacion',
+                'schema' => $schema,
             ],
         ],
     ];


### PR DESCRIPTION
## Summary
- ensure OpenAI request includes `text.format.schema` with the p5 JSON schema

## Testing
- `find includes -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689bcde9c68c8332877767c9442aa73e