### PR TITLE
fix: add type to not clause in p5 schema

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -14,7 +14,13 @@ function tanviz_p5_json_schema() {
                 'minLength' => 50,
                 'maxLength' => 200000,
                 'pattern' => '(?s)function\\s+setup\\s*\\(\\)[\\s\\S]*function\\s+draw\\s*\\(\\)',
-                'not' => [ 'pattern' => '<\\s*(html|head|body|script|style)\\b' ],
+                // Ensure prohibited HTML tags are not present. The subschema used in
+                // the "not" keyword must explicitly declare its type to satisfy
+                // the API's JSON schema validator.
+                'not' => [
+                    'type'    => 'string',
+                    'pattern' => '<\\s*(html|head|body|script|style)\\b',
+                ],
             ],
             'variables' => [
                 'type' => 'array',


### PR DESCRIPTION
## Summary
- specify string type within `not` rule to comply with API validator

## Testing
- `php -l includes/schema.php`

------
https://chatgpt.com/codex/tasks/task_e_689c3709466c83328c317a184efa3389