### PR TITLE
Ensure JSON schema objects disallow unknown fields

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -63,12 +63,16 @@ function tanviz_p5_json_schema() {
                     'required' => [ 'key', 'label', 'type', 'default' ],
                     'anyOf' => [
                         [
+                            'type' => 'object',
+                            'additionalProperties' => false,
                             'properties' => [
                                 'type'    => [ 'const' => 'number' ],
                                 'default' => [ 'type' => 'number' ],
                             ],
                         ],
                         [
+                            'type' => 'object',
+                            'additionalProperties' => false,
                             'properties' => [
                                 'type'    => [ 'const' => 'range' ],
                                 'default' => [ 'type' => 'number' ],
@@ -79,25 +83,32 @@ function tanviz_p5_json_schema() {
                             'required' => [ 'min', 'max', 'step' ],
                         ],
                         [
+                            'type' => 'object',
+                            'additionalProperties' => false,
                             'properties' => [
                                 'type'    => [ 'const' => 'boolean' ],
                                 'default' => [ 'type' => 'boolean' ],
                             ],
                         ],
                         [
+                            'type' => 'object',
+                            'additionalProperties' => false,
                             'properties' => [
                                 'type'    => [ 'const' => 'text' ],
-                        
                                 'default' => [ 'type' => 'string' ],
                             ],
                         ],
                         [
+                            'type' => 'object',
+                            'additionalProperties' => false,
                             'properties' => [
                                 'type'    => [ 'const' => 'color' ],
                                 'default' => [ 'type' => 'string', 'pattern' => '^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$' ],
                             ],
                         ],
                         [
+                            'type' => 'object',
+                            'additionalProperties' => false,
                             'properties' => [
                                 'type'    => [ 'const' => 'select' ],
                                 'default' => [


### PR DESCRIPTION
## Summary
- Add `type: object` and `additionalProperties: false` to each variant in the `variables` schema so the response format is accepted by the API

## Testing
- `php -l includes/schema.php`
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689c3d32990883329062f80900d975df