### PR TITLE
Specify additionalProperties in response schema

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -26,5 +26,6 @@ function tanviz_p5_json_schema() {
             ],
         ],
         'required' => [ 'codigo', 'titulo' ],
+        'additionalProperties' => false,
     ];
 }


### PR DESCRIPTION
## Summary
- ensure the tanviz p5 visualization JSON schema disallows extra properties per API requirements

## Testing
- `php -l includes/schema.php`
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689c8c64cc4c83328bff557d86402939