### PR TITLE
Simplify p5.js response schema

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -9,23 +9,12 @@ function tanviz_p5_json_schema() {
                 'type'        => 'string',
                 'description' => 'Código p5.js que genera la visualización.',
             ],
-            'titulo' => [
-                'type'        => 'string',
-                'description' => 'Nombre o título de la visualización.',
-            ],
             'descripcion' => [
                 'type'        => 'string',
                 'description' => 'Descripción breve de la visualización.',
             ],
-            'tags' => [
-                'type'        => 'array',
-                'description' => 'Palabras clave para clasificar la visualización.',
-                'items'       => [
-                    'type' => 'string',
-                ],
-            ],
         ],
-        'required' => [ 'codigo', 'titulo' ],
+        'required' => [ 'codigo', 'descripcion' ],
         'additionalProperties' => false,
     ];
 }


### PR DESCRIPTION
## Summary
- Reduce response JSON schema to minimal fields
- Require `codigo` and `descripcion` for p5.js visualization output

## Testing
- `php -l includes/schema.php`


------
https://chatgpt.com/codex/tasks/task_e_689c8e1421a48332b30e36ba708d01ee