### PR TITLE
Handle 'codigo' responses in sandbox

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -37,9 +37,11 @@
       data: JSON.stringify(body),
     }).done(function(resp){
       $('#tanviz-rr').text(JSON.stringify({request:body,response:resp},null,2));
-      if (resp && resp.structured && resp.structured.code){
-        setCode(resp.structured.code);
-        writeIframe(resp.structured.code, $('#tanviz-title').val() || (resp.structured.meta && resp.structured.meta.title));
+      const code = resp && (resp.codigo || (resp.structured && resp.structured.code));
+      if (code){
+        setCode(code);
+        const title = $('#tanviz-title').val() || resp.titulo || (resp.structured && resp.structured.meta && resp.structured.meta.title);
+        writeIframe(code, title);
       }
     }).fail(function(xhr){
       $('#tanviz-rr').text(xhr.responseText || 'Error');

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -58,7 +58,7 @@ function tanviz_render_sandbox(){
           <h2><?php echo esc_html__('Dataset sample','TanViz'); ?></h2>
           <pre id="tanviz-sample"></pre>
           <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button>
-             <button class="button" id="tanviz-preview"><?php echo esc_html__('Update preview','TanViz'); ?></button></p>
+             <button class="button" id="tanviz-preview"><?php echo esc_html__('Run code','TanViz'); ?></button></p>
           <h2><?php echo esc_html__('Title & Slug','TanViz'); ?></h2>
           <input type="text" id="tanviz-title" class="regular-text" placeholder="Title">
           <input type="text" id="tanviz-slug" class="regular-text code" placeholder="slug-for-visualization">


### PR DESCRIPTION
## Summary
- Support API responses that use `codigo` instead of `code` in sandbox
- Rename sandbox preview button to "Run code" for clarity

## Testing
- `node --check assets/admin.js`
- `php -l includes/admin-ui.php`


------
https://chatgpt.com/codex/tasks/task_e_689c984f4f488332bd1df4e2fa22f7e8