### PR TITLE
Improve sandbox usability and error reporting

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -17,7 +17,7 @@
       <style>html,body{margin:0;height:100%;}#wrap{position:relative;height:100%;}
       #ovl{position:absolute;top:8px;left:8px;display:flex;align-items:center;gap:.5rem;font:14px/1.2 system-ui}
       #ovl img{height:24px}</style>
-      <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js" crossorigin="anonymous"></script>
       <script>
         window.onerror = function(msg, src, line, col){
           parent.postMessage({type:'tanviz-error', message: msg+' ('+line+':'+col+')'}, '*');
@@ -155,6 +155,12 @@
   $(document).on('click','#tanviz-copy-rr',function(e){
     e.preventDefault();
     const txt = $('#tanviz-rr').text();
+    if (txt){ navigator.clipboard.writeText(txt).then(()=>alert('Copied')); }
+  });
+
+  $(document).on('click','#tanviz-copy-console',function(e){
+    e.preventDefault();
+    const txt = $('#tanviz-console').text();
     if (txt){ navigator.clipboard.writeText(txt).then(()=>alert('Copied')); }
   });
 

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -47,7 +47,7 @@ function tanviz_render_sandbox(){
       <div class="tanviz-grid">
         <section>
           <h2><?php echo esc_html__('Prompt','TanViz'); ?></h2>
-          <textarea id="tanviz-prompt" rows="6" class="large-text" placeholder="Describe the generative p5.js visualization you want..."></textarea>
+          <textarea id="tanviz-prompt" rows="6" class="large-text" placeholder="Describe the generative p5.js visualization you want...">crea el código de una visualización generativa impactante sobre el dataset adjunto</textarea>
           <h2><?php echo esc_html__('Dataset','TanViz'); ?></h2>
           <select id="tanviz-dataset">
             <option value=""><?php echo esc_html__('-- choose --','TanViz'); ?></option>
@@ -77,7 +77,7 @@ function tanviz_render_sandbox(){
           <h2><?php echo esc_html__('Preview','TanViz'); ?></h2>
           <iframe id="tanviz-iframe" sandbox="allow-scripts allow-same-origin"></iframe>
           <h2><?php echo esc_html__('Console','TanViz'); ?></h2>
-          <pre id="tanviz-console"></pre>
+          <pre id="tanviz-console"></pre><p><button class="button" id="tanviz-copy-console"><?php echo esc_html__('Copy','TanViz'); ?></button></p>
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add default Spanish prompt for sandbox requests
- Provide copy-to-clipboard button for console output
- Load p5.js with CORS to show detailed script errors

## Testing
- `node --check assets/admin.js`
- `php -l includes/admin-ui.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd012808c8332825e82ba253a6b8f