### PR TITLE
Remove redundant Run code button

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -68,11 +68,6 @@
     });
   });
 
-  $(document).on('click','#tanviz-preview',function(e){
-    e.preventDefault();
-    writeIframe(getCode(), $('#tanviz-title').val());
-  });
-
   $(document).on('click','#tanviz-export',function(e){
     e.preventDefault();
     const ifr = document.getElementById('tanviz-iframe');

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -57,8 +57,7 @@ function tanviz_render_sandbox(){
           </select>
           <h2><?php echo esc_html__('Dataset sample','TanViz'); ?></h2>
           <pre id="tanviz-sample"></pre>
-          <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button>
-             <button class="button" id="tanviz-preview"><?php echo esc_html__('Run code','TanViz'); ?></button></p>
+          <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button></p>
           <h2><?php echo esc_html__('Title & Slug','TanViz'); ?></h2>
           <input type="text" id="tanviz-title" class="regular-text" placeholder="Title">
           <input type="text" id="tanviz-slug" class="regular-text code" placeholder="slug-for-visualization">


### PR DESCRIPTION
## Summary
- Remove extra "Run code" button under dataset sample, leaving only a single "Generate visualization" button.
- Clean up JavaScript by deleting the unused preview handler.

## Testing
- `php -l includes/admin-ui.php`
- `node --check assets/admin.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689d6858b9c48332a446ea785a261152