### PR TITLE
Reorganize sandbox layout

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -2,5 +2,6 @@
 @media(min-width:900px){.tanviz-grid{grid-template-columns:1fr 1fr}}
 @media(min-width:1200px){.tanviz-grid{grid-template-columns:1fr 1fr 1fr}}
 .tanviz-grid section{background:#fff;border:1px solid #ccd0d4;padding:1rem}
+.tanviz-meta{background:#fff;border:1px solid #ccd0d4;padding:1rem;margin-top:1rem}
 .tanviz-wrap iframe{width:100%;aspect-ratio:16/9;border:1px solid #ccd0d4}
 #tanviz-sample,#tanviz-rr,#tanviz-console{max-height:40vh;overflow:auto;background:#f8f8f8;padding:.5rem;border:1px solid #ccd0d4;white-space:pre-wrap}

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -59,13 +59,6 @@ function tanviz_render_sandbox(){
           <pre id="tanviz-sample"></pre>
           <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button>
              <button class="button" id="tanviz-preview"><?php echo esc_html__('Run code','TanViz'); ?></button></p>
-          <h2><?php echo esc_html__('Title & Slug','TanViz'); ?></h2>
-          <input type="text" id="tanviz-title" class="regular-text" placeholder="Title">
-          <input type="text" id="tanviz-slug" class="regular-text code" placeholder="slug-for-visualization">
-          <p><button class="button" id="tanviz-save"><?php echo esc_html__('Save to Library','TanViz'); ?></button>
-             <button class="button" id="tanviz-export"><?php echo esc_html__('Export PNG','TanViz'); ?></button>
-             <button class="button" id="tanviz-export-gif"><?php echo esc_html__('Export GIF','TanViz'); ?></button>
-             <button class="button" id="tanviz-copy-iframe"><?php echo esc_html__('Copy iframe','TanViz'); ?></button></p>
         </section>
         <section>
           <h2><?php echo esc_html__('Code (p5.js)','TanViz'); ?></h2>
@@ -80,6 +73,15 @@ function tanviz_render_sandbox(){
           <pre id="tanviz-console"></pre><p><button class="button" id="tanviz-copy-console"><?php echo esc_html__('Copy','TanViz'); ?></button></p>
         </section>
       </div>
+      <section class="tanviz-meta">
+        <h2><?php echo esc_html__('Title & Slug','TanViz'); ?></h2>
+        <input type="text" id="tanviz-title" class="regular-text" placeholder="Title">
+        <input type="text" id="tanviz-slug" class="regular-text code" placeholder="slug-for-visualization">
+        <p><button class="button" id="tanviz-save"><?php echo esc_html__('Save to Library','TanViz'); ?></button>
+           <button class="button" id="tanviz-export"><?php echo esc_html__('Export PNG','TanViz'); ?></button>
+           <button class="button" id="tanviz-export-gif"><?php echo esc_html__('Export GIF','TanViz'); ?></button>
+           <button class="button" id="tanviz-copy-iframe"><?php echo esc_html__('Copy iframe','TanViz'); ?></button></p>
+      </section>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- Display code editor and preview sections immediately after dataset sample
- Move title/slug and export controls to a standalone meta box at page bottom
- Style new meta box to match existing layout

## Testing
- `php -l includes/admin-ui.php`


------
https://chatgpt.com/codex/tasks/task_e_689d68aba2388332ace8a4a8a705661e