### PR TITLE
Reorder sandbox sections and add meta box

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -4,3 +4,4 @@
 .tanviz-grid section{background:#fff;border:1px solid #ccd0d4;padding:1rem}
 .tanviz-wrap iframe{width:100%;aspect-ratio:16/9;border:1px solid #ccd0d4}
 #tanviz-sample,#tanviz-rr,#tanviz-console{max-height:40vh;overflow:auto;background:#f8f8f8;padding:.5rem;border:1px solid #ccd0d4;white-space:pre-wrap;overflow-wrap:anywhere}
+.tanviz-meta-box{background:#fff;border:1px solid #ccd0d4;padding:1rem;margin-top:1rem}

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -58,13 +58,6 @@ function tanviz_render_sandbox(){
           <h2><?php echo esc_html__('Dataset sample','TanViz'); ?></h2>
           <pre id="tanviz-sample"></pre>
           <p><button class="button button-primary" id="tanviz-generate"><?php echo esc_html__('Generate visualization','TanViz'); ?></button></p>
-          <h2><?php echo esc_html__('Title & Slug','TanViz'); ?></h2>
-          <input type="text" id="tanviz-title" class="regular-text" placeholder="Title">
-          <input type="text" id="tanviz-slug" class="regular-text code" placeholder="slug-for-visualization">
-          <p><button class="button" id="tanviz-save"><?php echo esc_html__('Save to Library','TanViz'); ?></button>
-             <button class="button" id="tanviz-export"><?php echo esc_html__('Export PNG','TanViz'); ?></button>
-             <button class="button" id="tanviz-export-gif"><?php echo esc_html__('Export GIF','TanViz'); ?></button>
-             <button class="button" id="tanviz-copy-iframe"><?php echo esc_html__('Copy iframe','TanViz'); ?></button></p>
         </section>
         <section>
           <h2><?php echo esc_html__('Code (p5.js)','TanViz'); ?></h2>
@@ -79,6 +72,15 @@ function tanviz_render_sandbox(){
           <pre id="tanviz-console"></pre><p><button class="button" id="tanviz-copy-console"><?php echo esc_html__('Copy','TanViz'); ?></button></p>
         </section>
       </div>
+      <section class="tanviz-meta-box">
+        <h2><?php echo esc_html__('Title & Slug','TanViz'); ?></h2>
+        <input type="text" id="tanviz-title" class="regular-text" placeholder="Title">
+        <input type="text" id="tanviz-slug" class="regular-text code" placeholder="slug-for-visualization">
+        <p><button class="button" id="tanviz-save"><?php echo esc_html__('Save to Library','TanViz'); ?></button>
+           <button class="button" id="tanviz-export"><?php echo esc_html__('Export PNG','TanViz'); ?></button>
+           <button class="button" id="tanviz-export-gif"><?php echo esc_html__('Export GIF','TanViz'); ?></button>
+           <button class="button" id="tanviz-copy-iframe"><?php echo esc_html__('Copy iframe','TanViz'); ?></button></p>
+      </section>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- Move sandbox title/slug and export controls into a dedicated meta box at the bottom of the page
- Ensure code editor and preview sections follow the dataset sample
- Style new meta box to match existing admin layout

## Testing
- `php -l includes/admin-ui.php`


------
https://chatgpt.com/codex/tasks/task_e_689d69c5f414833288c22b99277b0f8a