### PR TITLE
feat: add schema constraints for p5 sketch

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -7,7 +7,9 @@ function tanviz_p5_json_schema() {
         'properties' => [
             'codigo' => [
                 'type'        => 'string',
-                'description' => 'Código p5.js que genera la visualización.',
+                'minLength'   => 40,
+                'pattern'     => '(?is)(?=.*(function\\s+setup\\s*\\(|\\bsetup\\s*=\\s*function|p\\.setup\\s*=))(?=.*(function\\s+draw\\s*\\(|\\bdraw\\s*=\\s*function|p\\.draw\\s*=)).*',
+                'description' => 'Código p5.js que genera la visualización. Debe definir funciones setup() y draw().',
             ],
             'descripcion' => [
                 'type'        => 'string',


### PR DESCRIPTION
## Summary
- strengthen JSON schema for p5 code by requiring setup and draw functions and minimal length

## Testing
- `php -l includes/schema.php`


------
https://chatgpt.com/codex/tasks/task_e_689d6b623324833295542170d651277c