### PR TITLE
Ensure optional column roles included in schema

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -52,11 +52,13 @@ final class Schema
                         'column_roles' => [
                             'type' => 'object',
                             'additionalProperties' => false,
-                            'required' => ['year', 'value'],
+                            // Include all keys in "required" to satisfy OpenAI's JSON schema validator
+                            'required' => ['year', 'value', 'optional'],
                             'properties' => [
                                 'year' => ['type' => 'array', 'items' => ['type' => 'string'], 'minItems' => 1],
                                 'value' => ['type' => 'array', 'items' => ['type' => 'string'], 'minItems' => 1],
-                                'optional' => ['type' => 'array', 'items' => ['type' => 'string']],
+                                // Ensure the model always returns an array, even if empty
+                                'optional' => ['type' => 'array', 'items' => ['type' => 'string'], 'default' => []],
                             ],
                         ],
                     ],


### PR DESCRIPTION
## Summary
- require `optional` column role in dataset schema and default to empty array to satisfy OpenAI validator

## Testing
- `php -l includes/schema.php`
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d704f8bd08332aae5b61159f10d63