### PR TITLE
Use new json_schema format for OpenAI responses

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -66,9 +66,8 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'input' => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
         'text'  => [
             'format' => [
-                'type'   => 'json_schema',
-                'name'   => 'tanviz_p5_visualizacion',
-                'schema' => $schema,
+                'name'        => 'json_schema',
+                'json_schema' => $schema,
             ],
         ],
     ];


### PR DESCRIPTION
## Summary
- Update API call to pass JSON schema via `json_schema` field in `text.format`

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d710d5c6c8332960d39cb42ad3c06