### PR TITLE
fix: add text format type for OpenAI response

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -66,7 +66,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'input' => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
         'text'  => [
             'format' => [
-                'name'        => 'json_schema',
+                'type'        => 'json_schema',
                 'json_schema' => $schema,
             ],
         ],


### PR DESCRIPTION
## Summary
- set `text.format.type` to `json_schema` in REST generator to satisfy OpenAI API requirement

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d765e70b48332a4f09d9c135aa8aa