### PR TITLE
Fix missing text format type for OpenAI requests

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -66,8 +66,11 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'input' => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
         'text'  => [
             'format' => [
-                'name'        => 'json_schema',
-                'json_schema' => $schema,
+                'type'       => 'json_schema',
+                'json_schema' => [
+                    'name'   => $schema['title'] ?? 'TanVizResponse',
+                    'schema' => $schema,
+                ],
             ],
         ],
     ];


### PR DESCRIPTION
## Summary
- fix OpenAI Responses API call by adding required `text.format.type` field
- wrap JSON schema with name and schema properties

## Testing
- `php -l includes/rest.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d79c285348332813a08e56f0af142