### PR TITLE
Fix missing OpenAI text.format.name parameter

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -66,7 +66,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'input' => tanviz_build_user_content( $dataset_url, $prompt, 20 ),
         'text'  => [
             'format' => [
-                'type'       => 'json_schema',
+                'name'        => 'json_schema',
                 'json_schema' => [
                     'name'   => $schema['title'] ?? 'TanVizResponse',
                     'schema' => $schema,


### PR DESCRIPTION
## Summary
- include `format.name` when requesting JSON schema outputs from OpenAI responses API

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d7adc78b083329c836ef80b4fb8fa