### PR TITLE
Fix Responses API payload for structured text output

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -87,7 +87,7 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'input' => $prompt,
         'text'  => [
             'format' => [
-                'name' => 'json_schema',
+                'type' => 'json_schema',
                 'json_schema' => [
                     'name'   => 'TanVizResponse',
                     'schema' => $schema,


### PR DESCRIPTION
## Summary
- specify `json_schema` type in `text.format` when calling OpenAI Responses API

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d976433f08332ba88023e5366bf72