### PR TITLE
fix: add name to response format

### DIFF
--- a/includes/rest.php
+++ b/includes/rest.php
@@ -88,8 +88,8 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
         'text'  => [
             'format' => [
                 'type' => 'json_schema',
+                'name' => 'TanVizResponse',
                 'json_schema' => [
-                    'name'   => 'TanVizResponse',
                     'schema' => $schema,
                     'strict' => true,
                 ],


### PR DESCRIPTION
## Summary
- specify `name` in `text.format` for OpenAI Responses payload to match API requirements

## Testing
- `php -l includes/rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689d9c7a06048332b3a1254c42504d98