### PR TITLE
Ensure schema required list stays aligned with properties

### DIFF
--- a/includes/schema.php
+++ b/includes/schema.php
@@ -1,22 +1,26 @@
 <?php
+// Define the schema's properties once so the required list can be derived
+// automatically. This keeps the arrays perfectly aligned.
+$properties = [
+    'ok' => ['type' => 'boolean', 'const' => true],
+    'codigo' => ['type' => 'string', 'minLength' => 1],
+    'descripcion' => ['type' => 'string'],
+    'dataset_contract' => [
+        'type' => 'object',
+        'additionalProperties' => false,
+    ],
+    'placeholders' => [
+        'type' => 'object',
+        'additionalProperties' => ['type' => 'string'],
+    ],
+    'checks' => ['type' => 'array', 'items' => ['type' => 'string']],
+];
+
 return [
     '$schema' => 'https://json-schema.org/draft/2020-12/schema',
     'title' => 'TanVizResponse',
     'type' => 'object',
     'additionalProperties' => false,
-    'required' => ['ok','codigo','descripcion','dataset_contract','placeholders','checks'],
-    'properties' => [
-        'ok' => ['type' => 'boolean', 'const' => true],
-        'codigo' => ['type' => 'string', 'minLength' => 1],
-        'descripcion' => ['type' => 'string'],
-        'dataset_contract' => [
-            'type' => 'object',
-            'additionalProperties' => false,
-        ],
-        'placeholders' => [
-            'type' => 'object',
-            'additionalProperties' => ['type' => 'string'],
-        ],
-        'checks' => ['type' => 'array', 'items' => ['type' => 'string']],
-    ],
+    'required' => array_keys($properties),
+    'properties' => $properties,
 ];


### PR DESCRIPTION
## Summary
- derive required field names from schema properties
- document alignment of schema properties and required list

## Testing
- `php -l includes/schema.php`


------
https://chatgpt.com/codex/tasks/task_e_689da7d63ec88332802eca5e6942e39c