### PR TITLE
Add Fix button to correct p5.js code via API

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -147,6 +147,29 @@
     navigator.clipboard.writeText(getCode()).then(()=>alert('Copied'));
   });
 
+  $(document).on('click','#tanviz-fix',function(e){
+    e.preventDefault();
+    const code = getCode();
+    $('#tanviz-rr').text('Fixing...');
+    $('#tanviz-rr-wrap').prop('open', true);
+    $.ajax({
+      url: TanVizCfg.rest.fix,
+      method: 'POST',
+      headers: { 'X-WP-Nonce': TanVizCfg.nonce },
+      contentType: 'application/json',
+      data: JSON.stringify({ code })
+    }).done(function(resp){
+      const fixed = resp && resp.codigo;
+      if (fixed){
+        setCode(fixed);
+        const title = $('#tanviz-title').val();
+        writeIframe(fixed, title);
+      }
+    }).fail(function(xhr){
+      $('#tanviz-rr').text(xhr.responseText || 'Error');
+    });
+  });
+
   $(document).on('click','#tanviz-copy-rr',function(e){
     e.preventDefault();
     const txt = $('#tanviz-rr').text();

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -18,6 +18,7 @@ function tanviz_admin_assets( $hook ){
             'datasets' => esc_url_raw( rest_url('TanViz/v1/datasets') ),
             'sample'   => esc_url_raw( rest_url('TanViz/v1/sample') ),
             'save'     => esc_url_raw( rest_url('TanViz/v1/save') ),
+            'fix'      => esc_url_raw( rest_url('TanViz/v1/fix') ),
         ],
         'nonce' => wp_create_nonce('wp_rest'),
         'logo'  => esc_url( get_option('tanviz_logo_url', TANVIZ_URL.'assets/logo.png') ),
@@ -62,7 +63,8 @@ function tanviz_render_sandbox(){
         <section>
           <h2><?php echo esc_html__('Code (p5.js)','TanViz'); ?></h2>
           <textarea id="tanviz-code" rows="18" class="large-text code"></textarea>
-          <p><button class="button" id="tanviz-copy-code"><?php echo esc_html__('Copy code','TanViz'); ?></button></p>
+          <p><button class="button" id="tanviz-copy-code"><?php echo esc_html__('Copy code','TanViz'); ?></button>
+             <button class="button" id="tanviz-fix"><?php echo esc_html__('Fix','TanViz'); ?></button></p>
           <details id="tanviz-rr-wrap"><summary><?php echo esc_html__( 'Request/Response', 'TanViz' ); ?></summary><pre id="tanviz-rr"></pre><p><button class="button" id="tanviz-copy-rr"><?php echo esc_html__('Copy','TanViz'); ?></button></p></details>
         </section>
         <section>

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -47,6 +47,15 @@ add_action('rest_api_init', function(){
             'dataset_url' => ['required'=>false],
         ],
     ]);
+
+    register_rest_route('TanViz/v1','/fix',[
+        'methods'  => 'POST',
+        'permission_callback' => function(){ return current_user_can('manage_options'); },
+        'callback' => 'tanviz_rest_fix',
+        'args'     => [
+            'code' => ['required'=>true],
+        ],
+    ]);
 });
 
 function tanviz_rest_generate( WP_REST_Request $req ) {
@@ -115,6 +124,58 @@ function tanviz_rest_generate( WP_REST_Request $req ) {
     }
 
     return new WP_REST_Response( $response, 200 );
+}
+
+function tanviz_rest_fix( WP_REST_Request $req ) {
+    $api_key = trim( get_option( 'tanviz_api_key', '' ) );
+    if ( ! $api_key ) {
+        return new WP_REST_Response( [ 'error' => 'Missing API key' ], 400 );
+    }
+
+    $model = get_option( 'tanviz_model', 'gpt-4o-mini' );
+    $code  = tanviz_normalize_p5_code( (string) $req->get_param( 'code' ) );
+
+    $input = "corrige los errores en este código p5.js:\n\n" . $code;
+
+    $body = [
+        'model' => $model,
+        'input' => $input,
+    ];
+
+    $args = [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $api_key,
+            'Content-Type'  => 'application/json',
+        ],
+        'timeout' => 60,
+        'body'    => wp_json_encode( $body ),
+    ];
+
+    $resp = wp_remote_post( 'https://api.openai.com/v1/responses', $args );
+    if ( is_wp_error( $resp ) ) {
+        return new WP_REST_Response( [ 'error' => $resp->get_error_message() ], 500 );
+    }
+
+    $code_status = wp_remote_retrieve_response_code( $resp );
+    $raw  = wp_remote_retrieve_body( $resp );
+    $json = json_decode( $raw, true );
+    if ( $code_status < 200 || $code_status >= 300 || ! is_array( $json ) ) {
+        return new WP_REST_Response( [ 'error' => 'API error', 'raw' => $raw ], 500 );
+    }
+
+    $out = '';
+    if ( ! empty( $json['output_text'] ) ) {
+        $out = $json['output_text'];
+    } elseif ( ! empty( $json['output'][0]['content'][0]['text'] ) ) {
+        $out = $json['output'][0]['content'][0]['text'];
+    }
+    if ( ! $out ) {
+        return new WP_REST_Response( [ 'error' => 'No output', 'raw' => $json ], 502 );
+    }
+
+    $code_fixed = tanviz_normalize_p5_code( $out );
+
+    return new WP_REST_Response( [ 'ok' => true, 'codigo' => $code_fixed ], 200 );
 }
 
 function tanviz_rest_save( WP_REST_Request $req ) {


### PR DESCRIPTION
## Summary
- add `Fix` button in sandbox editor to send code for correction
- support new `TanViz/v1/fix` REST endpoint using OpenAI Responses API
- wire client JS to call endpoint and update preview

## Testing
- `php -l includes/admin-ui.php`
- `php -l includes/rest.php`
- `node --check assets/admin.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689df1fddfbc8332ae18752d35c098ca