### PR TITLE
Add run button and strip comments from fix output

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -147,6 +147,13 @@
     navigator.clipboard.writeText(getCode()).then(()=>alert('Copied'));
   });
 
+  $(document).on('click','#tanviz-run',function(e){
+    e.preventDefault();
+    const code = getCode();
+    const title = $('#tanviz-title').val();
+    writeIframe(code, title);
+  });
+
   $(document).on('click','#tanviz-fix',function(e){
     e.preventDefault();
     const code = getCode();
@@ -159,6 +166,7 @@
       contentType: 'application/json',
       data: JSON.stringify({ code })
     }).done(function(resp){
+      $('#tanviz-rr').text(JSON.stringify({request:{code},response:resp},null,2));
       const fixed = resp && resp.codigo;
       if (fixed){
         setCode(fixed);

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -64,7 +64,8 @@ function tanviz_render_sandbox(){
           <h2><?php echo esc_html__('Code (p5.js)','TanViz'); ?></h2>
           <textarea id="tanviz-code" rows="18" class="large-text code"></textarea>
           <p><button class="button" id="tanviz-copy-code"><?php echo esc_html__('Copy code','TanViz'); ?></button>
-             <button class="button" id="tanviz-fix"><?php echo esc_html__('Fix','TanViz'); ?></button></p>
+             <button class="button" id="tanviz-fix"><?php echo esc_html__('Fix','TanViz'); ?></button>
+             <button class="button" id="tanviz-run"><?php echo esc_html__('Run','TanViz'); ?></button></p>
           <details id="tanviz-rr-wrap"><summary><?php echo esc_html__( 'Request/Response', 'TanViz' ); ?></summary><pre id="tanviz-rr"></pre><p><button class="button" id="tanviz-copy-rr"><?php echo esc_html__('Copy','TanViz'); ?></button></p></details>
         </section>
         <section>

--- a/includes/structured.php
+++ b/includes/structured.php
@@ -52,6 +52,9 @@ function tanviz_is_valid_p5( $code ) {
 function tanviz_normalize_p5_code( $code ) {
     $code = preg_replace('/^```(?:p5|javascript|js)?\s*|\s*```$/m', '', $code);
     $code = preg_replace('#<\s*/?\s*script[^>]*>#i', '', $code);
+    // Strip multiline and single-line JS comments
+    $code = preg_replace('~/\*.*?\*/~s', '', $code);
+    $code = preg_replace('~(?<!:)//.*$~m', '', $code);
     return trim($code);
 }
 


### PR DESCRIPTION
## Summary
- add Run button to manually execute sketches and preview results
- log fix request/response and strip comments from AI output
- remove JavaScript comments during code normalization

## Testing
- `php -l includes/structured.php includes/admin-ui.php`
- `php -l includes/rest.php`
- `node --check assets/admin.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_689df6d39f78833287ee3bc57dc4a5f0