### PR TITLE
Handle CSV columns without case sensitivity

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -23,6 +23,7 @@
       #ovl{position:absolute;top:8px;left:8px;display:flex;align-items:center;gap:.5rem;font:14px/1.2 system-ui}
       #ovl img{height:24px}</style>
       <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js" crossorigin="anonymous"></script>
+      <script src="${TanVizCfg.ci}"></script>
       <script>
         window.onerror = function(msg, src, line, col){
           parent.postMessage({type:'tanviz-error', message: msg+' ('+line+':'+col+')'}, '*');

--- a/assets/table-ci.js
+++ b/assets/table-ci.js
@@ -1,0 +1,30 @@
+(function(){
+  function norm(table, col){
+    if (typeof col !== 'string') return col;
+    const cols = table.columns || [];
+    const idx = cols.map(c => String(c).toLowerCase()).indexOf(col.toLowerCase());
+    return idx === -1 ? col : cols[idx];
+  }
+  function wrap(target, name, colIndex){
+    const orig = target[name];
+    if (typeof orig !== 'function') return;
+    target[name] = function(...args){
+      if (args[colIndex] && typeof args[colIndex] === 'string') {
+        args[colIndex] = norm(this.table || this, args[colIndex]);
+      }
+      return orig.apply(this, args);
+    };
+  }
+  if (window.p5 && p5.Table && !p5.Table.__tanviz_ci){
+    wrap(p5.Table.prototype, 'get', 1);
+    wrap(p5.Table.prototype, 'getString', 1);
+    wrap(p5.Table.prototype, 'getNum', 1);
+    wrap(p5.Table.prototype, 'set', 1);
+    wrap(p5.Table.prototype, 'getColumn', 0);
+    wrap(p5.TableRow.prototype, 'get', 0);
+    wrap(p5.TableRow.prototype, 'getString', 0);
+    wrap(p5.TableRow.prototype, 'getNum', 0);
+    wrap(p5.TableRow.prototype, 'set', 0);
+    p5.Table.__tanviz_ci = true;
+  }
+})();

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -9,7 +9,8 @@ add_shortcode('TanViz', function( $atts ){
     $code = $post->post_content;
     $code = wp_kses_post( $code );
     wp_enqueue_script('p5', 'https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js', [], '1.9.0', true);
-    wp_add_inline_script('p5', "try{ new Function(" . wp_json_encode( $code ) . ")(); }catch(e){ console.error('TanViz error', e); }");
+    wp_enqueue_script('tanviz-ci', TANVIZ_URL.'assets/table-ci.js', ['p5'], TANVIZ_VERSION, true);
+    wp_add_inline_script('tanviz-ci', "try{ new Function(" . wp_json_encode( $code ) . ")(); }catch(e){ console.error('TanViz error', e); }");
     ob_start(); ?>
     <div class="tanviz-embed" data-slug="<?php echo esc_attr($atts['slug']); ?>"></div>
     <?php
@@ -31,8 +32,9 @@ function tanviz_handle_embed(){
     $code  = tanviz_normalize_p5_code( $post->post_content );
     $title = esc_html( get_the_title( $post ) );
     $logo  = esc_url( get_option('tanviz_logo_url', TANVIZ_URL.'assets/logo.png') );
+    $ci    = esc_url( TANVIZ_URL . 'assets/table-ci.js' );
     header('Content-Type: text/html; charset=utf-8');
-    echo "<!doctype html><html><head><meta charset='utf-8'><title>{$title}</title><style>html,body{margin:0;height:100%}#wrap{position:relative;height:100%}#ovl{position:absolute;top:8px;left:8px;display:flex;align-items:center;gap:.5rem;font:14px/1.2 system-ui}#ovl img{height:24px}</style><script src='https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js'></script></head><body><div id='wrap'><div id='ovl'><img src='{$logo}'/><div>{$title}</div></div></div><script>{$code}</script></body></html>";
+    echo "<!doctype html><html><head><meta charset='utf-8'><title>{$title}</title><style>html,body{margin:0;height:100%}#wrap{position:relative;height:100%}#ovl{position:absolute;top:8px;left:8px;display:flex;align-items:center;gap:.5rem;font:14px/1.2 system-ui}#ovl img{height:24px}</style><script src='https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js'></script><script src='{$ci}'></script></head><body><div id='wrap'><div id='ovl'><img src='{$logo}'/><div>{$title}</div></div></div><script>{$code}</script></body></html>";
     exit;
 }
 add_action('template_redirect','tanviz_handle_embed');

--- a/includes/admin-ui.php
+++ b/includes/admin-ui.php
@@ -23,6 +23,7 @@ function tanviz_admin_assets( $hook ){
         'nonce' => wp_create_nonce('wp_rest'),
         'logo'  => esc_url( get_option('tanviz_logo_url', TANVIZ_URL.'assets/logo.png') ),
         'embed' => esc_url( home_url('tanviz/embed/') ),
+        'ci'    => esc_url( TANVIZ_URL . 'assets/table-ci.js' ),
     ]);
     // Code editor for the sandbox editor textarea
     $settings = wp_enqueue_code_editor( [ 'type'=>'text/javascript' ] );


### PR DESCRIPTION
## Summary
- Add helper script to allow case-insensitive lookup of CSV headers in p5 tables
- Load the case-insensitive patch in admin sandbox and embedded visualizations
- Localize script URL for use in the iframe

## Testing
- `php -l includes/admin-ui.php`
- `php -l inc/shortcode.php`
- `node --check assets/admin.js`
- `node --check assets/table-ci.js`


------
https://chatgpt.com/codex/tasks/task_e_689ec9ee418483329055635d16f25029