### PR TITLE
fix: handle missing table columns

### DIFF
--- a/examples/temperature-anomaly/sketch.js
+++ b/examples/temperature-anomaly/sketch.js
@@ -1,4 +1,4 @@
-let table;
+let table, yearCol, anomalyCol;
 
 function preload() {
   table = loadTable(
@@ -13,6 +13,8 @@ function preload() {
 function setup() {
   createCanvas(windowWidth, windowHeight);
   noStroke();
+  yearCol = getColNameInsensitive(table, 'Year');
+  anomalyCol = getColNameInsensitive(table, 'Anomaly');
 }
 
 function draw() {
@@ -22,12 +24,28 @@ function draw() {
 
   for (let i = 0; i < totalRows; i++) {
     const row = table.getRow(i);
-    const year = row.getNum('Year');
-    const anomaly = row.getNum('Anomaly');
+    const year = row.getNum(yearCol);
+    const anomaly = row.getNum(anomalyCol);
     const x = map(year, 1880, 2024, 0, width);
     const y = map(anomaly, -2, 2, height, 0);
     
     fill(0, 100, 255, random(100, 255));
     ellipse(x, y, random(10, 30), random(10, 30));
   }
+}
+
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+}
+
+function getColNameInsensitive(tbl, target) {
+  if (!tbl || typeof target !== 'string') return target;
+  const cols = Array.isArray(tbl.columns) ? tbl.columns : [];
+  const lower = target.toLowerCase();
+  for (let i = 0; i < cols.length; i++) {
+    if (String(cols[i]).toLowerCase() === lower) {
+      return cols[i];
+    }
+  }
+  return target;
 }


### PR DESCRIPTION
## Summary
- prevent null column names by adding case-insensitive lookup fallback
- resize canvas on window resize to avoid rendering issues

## Testing
- `node --check examples/temperature-anomaly/sketch.js`
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ece0ee53c83328135169484e4327a