### PR TITLE
Load Generate Visualization prompt from JSON file

### DIFF
--- a/includes/structured.php
+++ b/includes/structured.php
@@ -59,99 +59,12 @@ function tanviz_normalize_p5_code( $code ) {
 }
 
 function tanviz_build_user_content( $dataset_url, $user_prompt, $sample_rows = 20 ) {
-    $input = <<<P5PROMPT
-Eres un experto desarrollador de código p5.js. Genera una visualización en p5.js a partir del dataset indicado y del objetivo creativo descrito por el usuario.
-
-OBJETIVO
-    • Entregar SOLO el código final de p5.js en el espacio para la edición de código que sea funcional, óptimo, sin errores y listo para ejecutarse.
-
-ENTRADAS
-PROMPT DEL USUARIO:
-{$user_prompt}
-
-DATASET:
-URL del dataset: {$dataset_url}
-(El dataset puede ser CSV o JSON. Usa los placeholders existentes, por ejemplo: {{col.year}}, {{col.value}}, etc.)
-
-⸻
-
-REGLAS DE GENERACIÓN (OBLIGATORIAS)
-    1. Estructura p5.js
-    • Incluir (según corresponda) preload(), setup(), draw(), windowResized() y funciones auxiliares como drawGenerativeVisualization().
-    • Declarar todas las variables de estado compartidas (table, dataJSON, years, values, minValue, maxValue y cualquier otra usada en varias funciones) una sola vez en el ámbito global (fuera de cualquier función).
-    • Prohibido redeclarar estas variables dentro de funciones (setup, draw, windowResized, etc.).
-    • Usar noLoop() y redraw() cuando el renderizado no sea animado.
-
-    2. Carga de datos
-    • Usar exclusivamente funciones de p5.js en preload() para {$dataset_url}:
-      – CSV: loadTable({$dataset_url}, 'csv', 'header')
-      – JSON: loadJSON({$dataset_url})
-    • Implementar y usar SIEMPRE esta función auxiliar para buscar columnas ignorando mayúsculas/minúsculas en tablas CSV:
-
-    ```js
-    function getColNameInsensitive(tbl, target) {
-      if (!tbl || !tbl.columns) return -1;
-      for (let c = 0; c < tbl.columns.length; c++) {
-        if (String(tbl.columns[c]).toLowerCase() === String(target).toLowerCase()) {
-          return c;
-        }
-      }
-      return -1;
-    }
-    ```
-
-    • No inventar datos de ejemplo; usar SOLO el dataset indicado.
-    • Respetar y reutilizar EXACTAMENTE los placeholders/variables/URLs existentes (p.ej., {{DATASET_URL}}, {{col.year}}, {{col.value}}).
-    • Antes de acceder a campos/columnas, comprobar su existencia (en CSV con getColNameInsensitive; en JSON comprobando claves/longitud).
-
-    3. Diseño y lógica
-    • Implementar la visualización solicitada por {$user_prompt} con escalas/rangos dinámicos (p.ej., detectar año mínimo/máximo si procede).
-    • Calcular minValue y maxValue a partir de los datos válidos. Si minValue === maxValue, ampliar ligeramente el rango para evitar divisiones por cero.
-    • Si la visualización lo requiere, incluir ejes básicos y/o línea de cero cuando caiga dentro del rango.
-    • Evitar patrones frágiles (eval, import dinámico, fetch/XHR manual fuera de p5.js).
-    • No añadir dependencias externas nuevas.
-
-    4. Robustez (métodos y manejo de errores)
-    • Mostrar un mensaje de diagnóstico en el canvas cuando falten columnas/llaves o no existan datos válidos.
-    • Incluir y usar una función drawGenerativeVisualization() que pinte la escena completa sin redefinir estado global.
-    • Incluir una función drawMessage(msg) que pinte mensajes de diagnóstico en el canvas si hay problemas.
-    • Si se dibujan ejes/etiquetas, incluir una función auxiliar (p.ej., drawAxesLabels(...)) y llamarla desde drawGenerativeVisualization().
-    • windowResized() debe llamar a drawGenerativeVisualization() reutilizando las variables globales (sin reprocesar el dataset innecesariamente).
-    • Manejar datasets grandes con eficiencia; evitar trabajo costoso dentro de draw() si no hay animación.
-
-    5. Estilo de salida
-    • SALIDA EXCLUSIVAMENTE EN FORMATO DE CÓDIGO JS (sin texto, comentarios, logs o anotaciones).
-    • No incluir banners, encabezados ni “explicaciones”.
-    • Prohibido usar console.log.
-
-    6. Compatibilidad
-    • Mantener la interfaz/nombres esperados por el entorno.
-    • Conservar exactamente los placeholders existentes; no cambiarlos.
-
-    7. Performance
-    • Optimizar cálculos fuera de draw() siempre que sea posible.
-    • No bloquear el hilo principal.
-    • Para visualizaciones no animadas, usar noLoop() y llamar a redraw() solo cuando sea necesario (p.ej., al redimensionar).
-
-⸻
-
-VALIDACIONES AUTOMÁTICAS (ANTES DE DEVOLVER EL CÓDIGO)
-    • ¿El archivo es completo, ejecutable en p5.js y sin errores de sintaxis?
-    • ¿Usa {$dataset_url} en preload() con loadTable/loadJSON según corresponda?
-    • ¿Se han conservado los placeholders/variables/URLs originales?
-    • ¿No contiene comentarios, texto adicional ni console.log?
-    • ¿Implementa fielmente el objetivo de {$user_prompt} con escalas/rangos dinámicos donde aplique?
-    • ¿Evita dependencias externas y patrones frágiles?
-    • ¿Las variables globales (years, values, etc.) están definidas solo una vez fuera de cualquier función?
-    • ¿Existe la función getColNameInsensitive() y se usa para acceder a columnas?
-    • ¿drawGenerativeVisualization() y drawMessage() existen y se usan correctamente?
-    • ¿windowResized() llama a drawGenerativeVisualization() y no redeclara variables globales?
-    • ¿Se evita el rango nulo (minValue === maxValue) ajustando el dominio antes de mapear?
-
-⸻
-
-FORMATO DE RESPUESTA (ESTRICTO)
-Devuelve ÚNICAMENTE el código final del archivo p5.js, sin ningún texto antes o después.
-P5PROMPT;
-    return $input;
+    $file = TANVIZ_PATH . "prompts/generate_visualization.json";
+    if ( ! file_exists( $file ) ) return "";
+    $json = file_get_contents( $file );
+    if ( $json === false ) return "";
+    $json = str_replace( ["{{PROMPT_USUARIO}}", "{{DATASET_URL}}"], [ $user_prompt, $dataset_url ], $json );
+    $data = json_decode( $json, true );
+    if ( json_last_error() !== JSON_ERROR_NONE ) return "";
+    return $data;
 }

--- a/prompts/generate_visualization.json
+++ b/prompts/generate_visualization.json
@@ -1,0 +1,50 @@
+{
+  "name": "generate_visualization",
+  "description": "Prompt para generar visualizaciones p5.js a partir de un dataset y un objetivo creativo.",
+  "variables": [
+    {
+      "key": "PROMPT_USUARIO",
+      "description": "Texto introducido por el usuario que describe el objetivo creativo de la visualización.",
+      "example": "Mostrar la evolución de la temperatura media global con un fondo degradado."
+    },
+    {
+      "key": "DATASET_URL",
+      "description": "URL directa al dataset en formato CSV o JSON.",
+      "example": "https://raw.githubusercontent.com/usuario/datasets/main/temperaturas.csv"
+    },
+    {
+      "key": "col.year",
+      "description": "Nombre genérico de la columna que contiene los años.",
+      "example": "year"
+    },
+    {
+      "key": "col.value",
+      "description": "Nombre genérico de la columna que contiene los valores numéricos de la serie temporal.",
+      "example": "value"
+    }
+  ],
+  "sections": {
+    "role": "Eres un experto desarrollador de código p5.js. Genera una visualización en p5.js a partir del dataset indicado y del objetivo creativo descrito por el usuario.",
+    "objective": [
+      "Entregar SOLO el código final de p5.js en el espacio para la edición de código.",
+      "El código debe ser funcional, óptimo, sin errores y listo para ejecutarse."
+    ],
+    "inputs": {
+      "prompt_usuario": "{{PROMPT_USUARIO}}",
+      "dataset_url": "{{DATASET_URL}}",
+      "dataset_notes": "El dataset puede ser CSV o JSON. Usa los placeholders existentes, por ejemplo: {{col.year}}, {{col.value}}."
+    },
+    "rules": [
+      "Estructura p5.js: incluir (según corresponda) preload(), setup(), draw(), windowResized() y funciones auxiliares como drawGenerativeVisualization().",
+      "Declarar todas las variables de estado compartidas (table, years, values, minValue, maxValue y cualquier otra usada en varias funciones) una sola vez en el ámbito global.",
+      "Carga de datos: usar exclusivamente funciones de p5.js en preload() (loadTable, loadJSON) para {{DATASET_URL}}. No inventar datos ni columnas.",
+      "Procesamiento: usar {{col.year}}, {{col.value}} como referencia genérica para acceder a columnas, detectando el índice por nombre (insensible a mayúsculas/minúsculas).",
+      "Rango dinámico: calcular minValue y maxValue a partir de los datos cargados.",
+      "Visualización: usar map(), min(), max(), background(), stroke(), fill() y otras funciones de p5.js para representar los datos de forma creativa.",
+      "Compatibilidad: el código debe ser autónomo y ejecutable directamente en un entorno p5.js sin dependencias externas.",
+      "Sin código muerto: no incluir funciones o variables no usadas.",
+      "Limpieza: mantener indentación coherente, sin comentarios innecesarios.",
+      "Evitar patrones frágiles: no usar datos ficticios, eval(), import(), fetch() o XHR."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `prompts/generate_visualization.json` describing the Generate Visualization prompt template
- load and fill the prompt JSON in `tanviz_build_user_content`

## Testing
- `php -l includes/structured.php`
- `jq . prompts/generate_visualization.json >/dev/null && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_689f36d2f13c83328cca03475f0535b4