### PR TITLE
feat: generar p5.js sin structured output

### DIFF
--- a/TanViz.php
+++ b/TanViz.php
@@ -20,6 +20,8 @@ define( 'TANVIZ_URL',  plugin_dir_url( __FILE__ ) );
 add_action( 'plugins_loaded', function () {
     $files = [
         'includes/settings.php',
+        'includes/validators.php',
+        'includes/openai.php',
         'includes/structured.php',
         'includes/datasets.php',
         'includes/rest.php',

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -69,14 +69,20 @@
       data: JSON.stringify(body),
     }).done(function(resp){
       $('#tanviz-rr').text(JSON.stringify({request:body,response:resp},null,2));
-      const code = resp && (resp.codigo || (resp.structured && resp.structured.code));
-      if (code){
-        setCode(code);
-        const title = $('#tanviz-title').val() || resp.titulo || (resp.structured && resp.structured.meta && resp.structured.meta.title);
-        writeIframe(code, title);
+      if (resp && resp.success && resp.code){
+        setCode(resp.code);
+        const title = $('#tanviz-title').val();
+        writeIframe(resp.code, title);
+      } else {
+        $('#tanviz-console').text('Error inesperado. Reintenta.');
       }
     }).fail(function(xhr){
-      $('#tanviz-rr').text(xhr.responseText || 'Error');
+      let msg = xhr.responseJSON && xhr.responseJSON.message ? xhr.responseJSON.message : (xhr.responseText || 'Error');
+      if (xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.errors){
+        msg += '\n' + xhr.responseJSON.data.errors.join(', ');
+      }
+      $('#tanviz-console').text(msg + '\nReintenta.');
+      $('#tanviz-rr').text(msg);
     });
   });
 

--- a/includes/openai.php
+++ b/includes/openai.php
@@ -1,0 +1,99 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Calls OpenAI Responses API and extracts p5.js code block.
+ *
+ * @param array $args Arguments: dataset_url, prompt_usuario, feedback?, model?
+ * @return array
+ */
+function tanviz_openai_generate_code_only( array $args ): array {
+    $dataset_url   = isset( $args['dataset_url'] ) ? (string) $args['dataset_url'] : '';
+    $prompt_user   = isset( $args['prompt_usuario'] ) ? (string) $args['prompt_usuario'] : '';
+    $feedback      = isset( $args['feedback'] ) && is_array( $args['feedback'] ) ? $args['feedback'] : array();
+    $model         = isset( $args['model'] ) ? (string) $args['model'] : 'gpt-4o-2024-08-06';
+
+    $fb = array(
+        'root_causes'       => empty( $feedback['root_causes'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['root_causes'] ) ),
+        'blocking_errors'   => empty( $feedback['blocking_errors'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['blocking_errors'] ) ),
+        'policy_violations' => empty( $feedback['policy_violations'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['policy_violations'] ) ),
+        'improvements'      => empty( $feedback['improvements'] ) ? 'Ninguno' : sanitize_textarea_field( implode( '; ', (array) $feedback['improvements'] ) ),
+    );
+
+    $prompt = "Eres un experto en p5.js. Entrega ÚNICAMENTE el archivo final p5.js listo para ejecutar.\n\n" .
+        "ENTRADAS\n" .
+        "- PROMPT DEL USUARIO: {$prompt_user}\n" .
+        "- DATASET_URL: {$dataset_url}\n" .
+        "- Placeholders disponibles: {{col.year}}, {{col.value}} (no hardcodear cabeceras/URLs)\n\n" .
+        "CONTRATO OBLIGATORIO\n" .
+        "1) Estructura: define preload(), setup(), draw(), y windowResized() si procede. Declara helpers antes de usarlos.\n" .
+        "2) Carga de datos: usa SOLO funciones de p5.js (loadTable/loadJSON) con {$dataset_url}.\n" .
+        "3) Placeholders: usa {{col.*}} (p. ej., {{col.year}}, {{col.value}}). Prohibido datos de ejemplo/muestras.\n" .
+        "4) Rangos dinámicos: calcula yearMin/yearMax y min/max de valores.\n" .
+        "5) Prohibido: eval(), import(), fetch(), XHR, CSS externo.\n" .
+        "6) Respuesta: devuelve EXCLUSIVAMENTE el código entre:\n" .
+        "-----BEGIN_P5JS-----\n" .
+        "...AQUÍ VA EL CÓDIGO...\n" .
+        "-----END_P5JS-----\n\n" .
+        "DEFECTOS DETECTADOS EN LA EVALUACIÓN ANTERIOR (CORREGIR OBLIGATORIO)\n" .
+        "- Causas raíz: {$fb['root_causes']}\n" .
+        "- Errores bloqueantes: {$fb['blocking_errors']}\n" .
+        "- Violaciones de contrato: {$fb['policy_violations']}\n" .
+        "- Mejoras solicitadas: {$fb['improvements']}\n";
+
+    $body = array(
+        'model' => $model,
+        'temperature' => 0.2,
+        'max_output_tokens' => 3000,
+        'input' => array(
+            array( 'role' => 'system', 'content' => 'Eres un experto en p5.js. Entrega ÚNICAMENTE el archivo final p5.js entre marcadores.' ),
+            array( 'role' => 'user', 'content' => $prompt ),
+        ),
+    );
+
+    $args_http = array(
+        'headers' => array(
+            'Authorization' => 'Bearer ' . trim( get_option( 'tanviz_openai_api_key', '' ) ),
+            'Content-Type'  => 'application/json',
+        ),
+        'timeout' => 60,
+        'body'    => wp_json_encode( $body ),
+    );
+
+    $resp = wp_remote_post( 'https://api.openai.com/v1/responses', $args_http );
+    if ( is_wp_error( $resp ) ) {
+        return array( 'ok' => false, 'error' => $resp->get_error_message(), 'raw' => '' );
+    }
+
+    $raw  = wp_remote_retrieve_body( $resp );
+    $code = wp_remote_retrieve_response_code( $resp );
+    if ( $code < 200 || $code >= 300 ) {
+        return array( 'ok' => false, 'error' => 'http_' . $code, 'raw' => $raw );
+    }
+
+    $json = json_decode( $raw, true );
+    $text = '';
+    if ( is_array( $json ) ) {
+        if ( ! empty( $json['output'] ) && is_array( $json['output'] ) ) {
+            foreach ( $json['output'] as $item ) {
+                foreach ( ( $item['content'] ?? array() ) as $c ) {
+                    if ( isset( $c['text'] ) && is_string( $c['text'] ) ) {
+                        $text .= $c['text'];
+                    }
+                }
+            }
+        }
+        if ( $text === '' && isset( $json['output_text'] ) ) {
+            $text = (string) $json['output_text'];
+        }
+    } else {
+        $text = $raw;
+    }
+
+    $block = tanviz_extract_p5_block( $text );
+    if ( ! $block['ok'] ) {
+        return array( 'ok' => false, 'error' => 'no_block', 'raw' => $text );
+    }
+
+    return array( 'ok' => true, 'codigo' => $block['codigo'] );
+}

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -2,20 +2,20 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function tanviz_register_settings() {
-    register_setting( 'tanviz_settings', 'tanviz_api_key', [ 'type'=>'string', 'sanitize_callback'=>'sanitize_text_field' ] );
-    register_setting( 'tanviz_settings', 'tanviz_model',   [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'gpt-4o-mini' ] );
+    register_setting( 'tanviz_settings', 'tanviz_openai_api_key', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field' ] );
+    register_setting( 'tanviz_settings', 'tanviz_model', [ 'type' => 'string', 'sanitize_callback' => 'sanitize_text_field', 'default' => 'gpt-4o-2024-08-06' ] );
     register_setting( 'tanviz_settings', 'tanviz_datasets_base', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw' ] );
     register_setting( 'tanviz_settings', 'tanviz_logo_url', [ 'type'=>'string', 'sanitize_callback'=>'esc_url_raw', 'default'=> plugins_url('assets/logo.png', dirname(__FILE__,1) . '/../TanViz.php') ] );
 
     add_settings_section( 'tanviz_main', __( 'TanViz Settings', 'TanViz' ), function(){ echo '<p>'.esc_html__('Configure API and data sources.','TanViz').'</p>'; }, 'tanviz' );
 
-    add_settings_field( 'tanviz_api_key', __( 'OpenAI API Key', 'TanViz' ), function(){
-        $v = esc_attr( get_option('tanviz_api_key','') );
-        echo '<input type="password" name="tanviz_api_key" value="'.$v.'" class="regular-text" autocomplete="off" />';
+    add_settings_field( 'tanviz_openai_api_key', __( 'OpenAI API Key', 'TanViz' ), function(){
+        $v = esc_attr( get_option( 'tanviz_openai_api_key', '' ) );
+        echo '<input type="password" name="tanviz_openai_api_key" value="' . $v . '" class="regular-text" autocomplete="off" />';
     }, 'tanviz', 'tanviz_main' );
 
     add_settings_field( 'tanviz_model', __( 'OpenAI Model', 'TanViz' ), function(){
-        $v = esc_attr( get_option( 'tanviz_model', 'gpt-4o-mini' ) );
+        $v = esc_attr( get_option( 'tanviz_model', 'gpt-4o-2024-08-06' ) );
         echo '<input type="text" name="tanviz_model" value="' . $v . '" class="regular-text" />';
     }, 'tanviz', 'tanviz_main' );
 

--- a/includes/validators.php
+++ b/includes/validators.php
@@ -1,0 +1,42 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Extracts p5.js code block from text between markers.
+ *
+ * @param string $text Raw text from model.
+ * @return array
+ */
+function tanviz_extract_p5_block( string $text ): array {
+    if ( ! preg_match( '/-----BEGIN_P5JS-----\s*([\s\S]*?)\s*-----END_P5JS-----/u', $text, $m ) ) {
+        return array( 'ok' => false, 'error' => 'no_block' );
+    }
+    return array( 'ok' => true, 'codigo' => trim( $m[1] ) );
+}
+
+/**
+ * Validates p5.js code using regex checks.
+ *
+ * @param string $code Code to validate.
+ * @return array
+ */
+function tanviz_validate_p5_code( string $code ): array {
+    $checks = array(
+        'hasPreload'     => (bool) preg_match( '/function\s+preload\s*\(/', $code ),
+        'hasSetup'       => (bool) preg_match( '/function\s+setup\s*\(/', $code ),
+        'hasDraw'        => (bool) preg_match( '/function\s+draw\s*\(/', $code ),
+        'noBannedAPIs'   => ! preg_match( '/(eval\s*\(|XMLHttpRequest|fetch\s*\(|import\s*\(|<style>)/i', $code ),
+        'noFallbackData' => ! preg_match( '/(sampleData|dummy|placeholder\s*data)/i', $code ),
+    );
+    $errors = array();
+    foreach ( $checks as $k => $v ) {
+        if ( ! $v ) {
+            $errors[] = $k;
+        }
+    }
+    return array(
+        'ok'     => empty( $errors ),
+        'checks' => $checks,
+        'errors' => $errors,
+    );
+}


### PR DESCRIPTION
## Summary
- Integrate Responses API client that prompts for plain text and extracts p5.js code blocks
- Validate and fix generated code via regex checks and retry prompt
- Add settings for OpenAI key/model and update admin UI to display validation errors

## Testing
- `php -l TanViz.php includes/rest.php includes/openai.php includes/validators.php includes/settings.php`
- `phpcs TanViz.php includes/rest.php includes/openai.php includes/validators.php includes/settings.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6081ccdc83329c09d20b268084c2