### PR TITLE
Integrate lessons into visualization prompt

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,9 +1,11 @@
 # Lecciones aprendidas
 
-1. **Placeholders Incorrectos**: Haz de reemplazar `{{col.year}}` y `{{col.value}}` con los nombres correctos de las columnas en el CSV. Sin esto, el código no funcionará correctamente.
-2. **Cálculo de Rango**: La función `calculateRanges()` busca valores mínimos y máximos, lo cual es correcto. Sin embargo, asegúrate de que los datos no estén vacíos o mal formateados para evitar errores.
-3. **Visualización**: El uso de `beginShape()` y `endShape()` está bien para crear una línea, pero podrías considerar agregar puntos para mostrar mejor los datos.
-4. **Manejo de Errores**: Considera añadir manejo de errores para cargar el CSV, en caso de que la URL sea incorrecta o el archivo no esté disponible.
-5. **Reactividad**: La función `windowResized()` está correctamente configurada para redibujar el gráfico al cambiar el tamaño de la ventana, pero asegúrate de que el aspecto visual se mantenga adecuado en diferentes resoluciones.
-6. **Estilo Visual**: Podrías mejorar la visualización añadiendo etiquetas para los ejes y un título para dar contexto a los datos mostrados.
-7. **Optimización**: `noLoop()` evita que `draw()` se llame repetidamente, lo cual es eficiente para este tipo de visualización estática.
+- **Placeholders correctos**: Reemplaza `{{col.year}}` y `{{col.value}}` con los nombres reales de las columnas del dataset.
+- **Dependencia de `preload()`**: Esta función bloquea la ejecución hasta que los datos se cargan; toma en cuenta su impacto en el tiempo de carga.
+- **Manejo de errores**: Maneja errores en la carga de datos mostrando mensajes en la consola y, si es posible, también en la visualización.
+- **Verificación de `table`**: Cuando se usa `preload()`, la tabla estará disponible en `draw()` y no necesita comprobaciones redundantes.
+- **Cálculo y sincronización de rangos**: `calculateRanges()` debe considerar valores vacíos o no numéricos para evitar resultados incorrectos.
+- **Reactividad**: Usa `windowResized()` y `redraw()` o `loop()` para ajustar la visualización al cambiar el tamaño de la ventana.
+- **Estética y UX**: Añade etiquetas, títulos y usa color o grosor de línea para mejorar la comprensión del gráfico.
+- **Visualización**: `beginShape()`/`endShape()` pueden complementarse con puntos para destacar los datos.
+- **Optimización**: `noLoop()` es útil para evitar redibujos innecesarios en visualizaciones estáticas.

--- a/includes/structured.php
+++ b/includes/structured.php
@@ -87,5 +87,16 @@ function tanviz_build_user_content( $dataset_url, $user_prompt, $sample_rows = 2
         $parts[] = "REGLAS:\n- " . implode( "\n- ", array_map( 'trim', $sections['rules'] ) );
     }
 
+    $lessons_file = TANVIZ_PATH . "LESSONS.md";
+    if ( file_exists( $lessons_file ) ) {
+        $lessons = file_get_contents( $lessons_file );
+        if ( $lessons !== false ) {
+            $lessons = trim( preg_replace('/^#.*\n/', '', $lessons) );
+            if ( $lessons !== '' ) {
+                $parts[] = "LECCIONES:\n" . $lessons;
+            }
+        }
+    }
+
     return implode( "\n\n", $parts );
 }

--- a/prompts/generate_visualization.json
+++ b/prompts/generate_visualization.json
@@ -44,7 +44,8 @@
       "Compatibilidad: el código debe ser autónomo y ejecutable directamente en un entorno p5.js sin dependencias externas.",
       "Sin código muerto: no incluir funciones o variables no usadas.",
       "Limpieza: mantener indentación coherente, sin comentarios innecesarios.",
-      "Evitar patrones frágiles: no usar datos ficticios, eval(), import(), fetch() o XHR."
+      "Evitar patrones frágiles: no usar datos ficticios, eval(), import(), fetch() o XHR.",
+      "Aplica las lecciones aprendidas listadas en la sección LECCIONES."
     ]
   }
 }


### PR DESCRIPTION
## Summary
- centralize visualization lessons in `LESSONS.md` and expand guidance on preload, error handling, and UX
- inject lessons section into `tanviz_build_user_content` so prompts include `LESSONS.md`
- prompt generation now references lessons via new rule

## Testing
- `php -l includes/structured.php`
- `jq '.name' prompts/generate_visualization.json`


------
https://chatgpt.com/codex/tasks/task_e_689faa34140483328d1ca6a74a5047e2